### PR TITLE
fix: make meta not optional

### DIFF
--- a/src/SpecAction.ts
+++ b/src/SpecAction.ts
@@ -3,7 +3,7 @@ export interface SpecAction {
   type: string,
   name: string,
   payload: any,
-  meta?: { [k: string]: any },
+  meta: { [k: string]: any },
   // komondor/callback action does not have instanceId
   instanceId?: number,
   invokeId?: number,


### PR DESCRIPTION
While technically meta can be undefined when not used (to save space).
Making it optional means every time you use it you need to check if it is undefined.

And since you use it, you assume that your specific action will have meta defined.

The same argument as https://github.com/redux-utilities/flux-standard-action/pull/53