### PR TITLE
fix: add SpecAction.autoInvoke

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,6 +10,7 @@ export interface SpecAction {
   sourceInstanceId?: number,
   sourceInvokeId?: number,
   sourcePath?: (string | number)[],
+  autoInvoke?: boolean,
   returnType?: string,
   returnInstanceId?: number
 }


### PR DESCRIPTION
This is used to indicate the action should be invoked by the framework.

Needed to fix https://github.com/unional/komondor/issues/124